### PR TITLE
Database properties do not need POM to match local value

### DIFF
--- a/validateProperties.js
+++ b/validateProperties.js
@@ -122,7 +122,12 @@ const validateProperties = (folderInfo, pomInfo) => {
       `POM: ${key} property from ${localContext} not found`
     );
 
-    if (foundInPom && key !== "api.manager.flowref") {
+    if (
+      foundInPom &&
+      key !== "api.manager.flowref" &&
+      !key.includes("database") &&
+      !key.includes("sql")
+    ) {
       assert.equals(value, pomInfo.properties.get(key), `POM ${key}`);
     }
   });


### PR DESCRIPTION
For property names containing "database" or "sql", the property values in the POM do not need to match those in api.Local.properties. The property still needs to be present in the POM if it's in local, though.

Fixes #8 

Old:
```
mulint "C:\SourceCode\mulesoft-apis\System APIs\state-list-system-api\"

implementation.xml: db:template-query is not permitted
POM dbUfg.database.url: expected "${dbUfg.database.url}" but was "jdbc:sqlserver://CRSQLDEV01.CR.UNITEDFIREGROUP.COM;databaseName=dbUfg;user=user;password=password;"

```
New:
```
mulint "C:\SourceCode\mulesoft-apis\System APIs\state-list-system-api\"

implementation.xml: db:template-query is not permitted
```