### PR TITLE
clientTlsContext not required when using Mule mock service

### DIFF
--- a/validateGlobal.js
+++ b/validateGlobal.js
@@ -29,8 +29,10 @@ const validateGlobal = folderInfo => {
         let requestConfigAttributes = requestConfig["$"];
 
         let protocol = requestConfigAttributes.protocol;
+        let host = requestConfigAttributes["host"];
+        let usesMockService = host && host.includes("mock");
 
-        if (protocol === "HTTPS") {
+        if (protocol === "HTTPS" && !usesMockService) {
           let tlsContext = requestConfigAttributes["tlsContext-ref"];
 
           assert.equals(


### PR DESCRIPTION
If using the mule mock service, we don’t need to set a clientTlsContext. If we do use that things will fail since we have not imported that certificate into the client trust store.

Assumes that the host will include "mock" (case-sensitive).
This could be a hardcode like `mocksvc.mulesoft.com` or a placeholder like `${mockserver.host}`.

**Note:** If we found a placeholder we could look it up in the local properties file and see if its value contained "mocksvc". This would involve significant refactoring; as I only found one example under the Process APIs (and that used `${mockserver.host}`) I wasn't sure that the effort was warranted.

**Before:**

```
mulint "C:\SourceCode\mulesoft-apis\Process APIs\policyholder-account-process-api\"

Global Mock_Server_HTTP_Request_Configuration tlsContext: expected "clientTlsContext" but was "undefined"
```

**After:**

`mulint "C:\SourceCode\mulesoft-apis\Process APIs\policyholder-account-process-api\"`

_(no warnings)_

Fixes #6