### PR TITLE
Feature/log4j template checks

### DIFF
--- a/validateLog4j.js
+++ b/validateLog4j.js
@@ -17,6 +17,11 @@ const validateTemplateIsCurrent = (xml, databaseRoute) => {
     route => route["$"].key === "local"
   );
 
+  if (!localRoute) {
+    // very old template
+    error.fatal("Log4j local Route not found - check case of key");
+  }
+
   assert.equals("file", localRoute["$"].ref, "Log4j local Route");
 
   assert.equals(


### PR DESCRIPTION
Verify that log4j2.xml key elements match current template.

Sample warning output:

```
Log4j Routing Script: expected ""${mule.env}".equals("local") ? "local" : "DB";" but was ""${sys:mule.env}" == "local" ? "local" : "DB";"
Log4j local Route: expected "file" but was "console"
Log4j AppenderRef: expected "Routing" but was "file"
Log4 JDBC MULESOFT_ENV literal: expected "'${mule.env}'" but was "'${sys:mule.env}'"
Log4 JDBC tableName: expected "MULESOFT_LOGS" but was "MULESOFT.MULESOFT_LOGS"
```

Closes #9 