### PR TITLE
Skip target folder when checking for .gitignore files

### DIFF
--- a/folderParser.js
+++ b/folderParser.js
@@ -65,7 +65,7 @@ const folderParser = apiBasePath => {
     error.fatal(`.gitignore file "${gitignoreFile}" not found`);
   }
 
-  const gitIgnoredFoldersAndFilesRegEx = /src[/\\]main[/\\]api[/\\]\.repository[/\\]|src[/\\]main[/\\]api[/\\]\.gitignore/;
+  const gitIgnoredFoldersAndFilesRegEx = /src[/\\]main[/\\]api[/\\]\.repository[/\\]|src[/\\]main[/\\]api[/\\]\.gitignore|[/\\]target[/\\]/;
 
   if (
     search


### PR DESCRIPTION
Skip `/target/` folder when checking for .gitignore files.

`target/` is in standard .gitignore.

Fixes #14 