### PR TITLE
Bypass global host and port checks when using mock service

### DIFF
--- a/validateGlobal.js
+++ b/validateGlobal.js
@@ -32,7 +32,11 @@ const validateGlobal = folderInfo => {
         let host = requestConfigAttributes["host"];
         let usesMockService = host && host.includes("mock");
 
-        if (protocol === "HTTPS" && !usesMockService) {
+        if (usesMockService) {
+          return; // continue forEach, skip remaining checks
+        }
+
+        if (protocol === "HTTPS") {
           let tlsContext = requestConfigAttributes["tlsContext-ref"];
 
           assert.equals(


### PR DESCRIPTION
If we add more checks on HTTP request configurations in the future, this will bypass those as well for configurations that use the mock service.

**Example:**
```
<http:request-config name="Mock_HTTP_Request_Configuration" protocol="HTTPS" host="mocksvc.mulesoft.com" port="443" basePath="/mocks/..." doc:name="HTTP Request Configuration" />
```

**Before:**
```
Global Mock_HTTP_Request_Configuration host: expected matching /^\${.+}$/ but was "mocksvc.mulesoft.com"
Global Mock_HTTP_Request_Configuration port: expected matching /^\${.+}$/ but was "443"
```

**After:**
_(no warnings)_

