### PR TITLE
Check both implementation XML and muleflows folder if found

### DIFF
--- a/folderParser.js
+++ b/folderParser.js
@@ -6,12 +6,13 @@ const error = require("./error");
 
 const findImplementationFiles = appFolder => {
   let usualFile = path.join(appFolder, "implementation.xml");
+  let muleflows = glob.sync(path.join(appFolder, "muleflows", "*.xml"));
 
   if (fs.existsSync(usualFile)) {
-    return [usualFile];
+    muleflows.unshift(usualFile);
   }
 
-  return glob.sync(path.join(appFolder, "muleflows", "*.xml"));
+  return muleflows;
 };
 
 const folderParser = apiBasePath => {


### PR DESCRIPTION
Previously if an implementation.xml file existed, it would not check the files under muleflows/.

Fixes #16 

**Before (with modified test project):**

```
implementation.xml: junk is not permitted
```

**After (latter two files are under muleflows/):**

```
implementation.xml: junk is not permitted
billing_agency.xml: foo is not permitted
loss_yeartodate.xml: bogus is not permitted
```