### PR TITLE
Improve XML parsing error messages

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -6,7 +6,10 @@ const cloudCIOnlyMavenProperties = [
   "anypoint.platform.client_secret"
 ];
 
+const encoding = "utf8";
+
 module.exports = {
   propertyPlaceholderRegEx,
-  cloudCIOnlyMavenProperties
+  cloudCIOnlyMavenProperties,
+  encoding
 };

--- a/mulint.js
+++ b/mulint.js
@@ -15,7 +15,7 @@ const validateDataWeaveFiles = require("./validateDataWeaveFiles");
 const assert = require("./assert");
 
 program
-  .version("1.3.0")
+  .version("1.3.1")
   .description("Mule project linter")
   .arguments("<apiBasePath>")
   .on("--help", () => {

--- a/pomParser.js
+++ b/pomParser.js
@@ -1,27 +1,13 @@
-const fs = require("fs");
-const xml2js = require("xml2js");
-const error = require("./error");
+const xmlParser = require("./xmlParser");
 
 const pomParser = pomFile => {
-  let contents = fs.readFileSync(pomFile);
-  let parser = new xml2js.Parser();
+  let { xml } = xmlParser(pomFile);
+  let xmlProperties = xml.project.properties[0];
   let properties = new Map();
-  let xml;
 
-  // synchronous by default in current version of xml2js
-  parser.parseString(contents, (err, result) => {
-    if (err) {
-      error.fatal(err);
-    }
-
-    xml = result;
-
-    let xmlProperties = xml.project.properties[0];
-
-    for (let property in xmlProperties) {
-      properties.set(property, xmlProperties[property][0]);
-    }
-  });
+  for (let property in xmlProperties) {
+    properties.set(property, xmlProperties[property][0]);
+  }
 
   let isOnPrem = properties.get("deployment.type") === "arm";
 

--- a/validateDataWeaveFiles.js
+++ b/validateDataWeaveFiles.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const assert = require("./assert");
+const { encoding } = require("./constants");
 
 // Possible false positive - might be line comment
 // as opposed to commented-out code.
@@ -13,8 +14,7 @@ const validateDataWeaveFiles = folderInfo => {
     let context = path.basename(dataWeaveFile);
 
     let lines = fs
-      .readFileSync(dataWeaveFile)
-      .toString()
+      .readFileSync(dataWeaveFile, encoding)
       .split(os.EOL);
 
     let isCommentedOutLine = false;

--- a/validateGitignore.js
+++ b/validateGitignore.js
@@ -1,8 +1,9 @@
 const fs = require("fs");
 const assert = require("./assert");
+const { encoding } = require("./constants");
 
 const validateGitignore = folderInfo => {
-  let contents = fs.readFileSync(folderInfo.gitignoreFile).toString();
+  let contents = fs.readFileSync(folderInfo.gitignoreFile, encoding);
 
   assert.isTrue(
     /^\.project\s*$/m.test(contents),

--- a/validateGlobal.js
+++ b/validateGlobal.js
@@ -1,96 +1,87 @@
 const { propertyPlaceholderRegEx } = require("./constants");
-const fs = require("fs");
-const xml2js = require("xml2js");
-const error = require("./error");
+const xmlParser = require("./xmlParser");
 const assert = require("./assert");
 
 const expectedTlsContext = "clientTlsContext";
 
 const validateGlobal = folderInfo => {
-  let contents = fs.readFileSync(folderInfo.globalFile);
-  let parser = new xml2js.Parser();
+  let { contents, xml } = xmlParser(folderInfo.globalFile);
 
   assert.isTrue(
     !contents.includes("<db:dynamic-query>"),
     "Global: Dynamic query is not permitted - vulnerable to SQL injection"
   );
 
-  parser.parseString(contents, (err, result) => {
-    if (err) {
-      error.fatal(err);
-    }
+  assert.isTrue(
+    xml.mule["api-platform-gw:api"] &&
+      xml.mule["api-platform-gw:api"][0]["$"]["doc:name"] ===
+        "API Autodiscovery",
+    "Global: API Autodiscovery not configured"
+  );
 
-    assert.isTrue(
-      result.mule["api-platform-gw:api"] &&
-        result.mule["api-platform-gw:api"][0]["$"]["doc:name"] ===
-          "API Autodiscovery",
-      "Global: API Autodiscovery not configured"
-    );
+  let requestConfigs = xml.mule["http:request-config"];
 
-    let requestConfigs = result.mule["http:request-config"];
+  if (requestConfigs) {
+    requestConfigs.forEach(requestConfig => {
+      let requestConfigAttributes = requestConfig["$"];
 
-    if (requestConfigs) {
-      requestConfigs.forEach(requestConfig => {
-        let requestConfigAttributes = requestConfig["$"];
+      let protocol = requestConfigAttributes.protocol;
+      let host = requestConfigAttributes["host"];
+      let usesMockService = host && host.includes("mock");
 
-        let protocol = requestConfigAttributes.protocol;
-        let host = requestConfigAttributes["host"];
-        let usesMockService = host && host.includes("mock");
+      if (usesMockService) {
+        return; // continue forEach, skip remaining checks
+      }
 
-        if (usesMockService) {
-          return; // continue forEach, skip remaining checks
-        }
+      if (protocol === "HTTPS") {
+        let tlsContext = requestConfigAttributes["tlsContext-ref"];
 
-        if (protocol === "HTTPS") {
-          let tlsContext = requestConfigAttributes["tlsContext-ref"];
+        assert.equals(
+          expectedTlsContext,
+          tlsContext,
+          `Global ${requestConfigAttributes.name} tlsContext`
+        );
+      }
 
-          assert.equals(
-            expectedTlsContext,
-            tlsContext,
-            `Global ${requestConfigAttributes.name} tlsContext`
-          );
-        }
+      assert.matches(
+        propertyPlaceholderRegEx,
+        requestConfigAttributes.host,
+        `Global ${requestConfigAttributes.name} host`
+      );
 
-        assert.matches(
-          propertyPlaceholderRegEx,
-          requestConfigAttributes.host,
-          `Global ${requestConfigAttributes.name} host`
+      assert.matches(
+        propertyPlaceholderRegEx,
+        requestConfigAttributes.port,
+        `Global ${requestConfigAttributes.name} port`
+      );
+    });
+  }
+
+  let templateQueries = xml.mule["db:template-query"];
+
+  if (templateQueries) {
+    templateQueries.forEach(templateQuery => {
+      let query = templateQuery["db:parameterized-query"];
+
+      if (query) {
+        let queryAttributes = query[0]["$"];
+        let isFileQuery = queryAttributes && queryAttributes.file;
+
+        assert.isTrue(
+          isFileQuery,
+          "Global: Inline SQL should be moved to file"
         );
 
-        assert.matches(
-          propertyPlaceholderRegEx,
-          requestConfigAttributes.port,
-          `Global ${requestConfigAttributes.name} port`
-        );
-      });
-    }
-
-    let templateQueries = result.mule["db:template-query"];
-
-    if (templateQueries) {
-      templateQueries.forEach(templateQuery => {
-        let query = templateQuery["db:parameterized-query"];
-
-        if (query) {
-          let queryAttributes = query[0]["$"];
-          let isFileQuery = queryAttributes && queryAttributes.file;
-
-          assert.isTrue(
-            isFileQuery,
-            "Global: Inline SQL should be moved to file"
+        if (isFileQuery) {
+          assert.matches(
+            /^sql\//,
+            queryAttributes.file,
+            "Global: Database query file"
           );
-
-          if (isFileQuery) {
-            assert.matches(
-              /^sql\//,
-              queryAttributes.file,
-              "Global: Database query file"
-            );
-          }
         }
-      });
-    }
-  });
+      }
+    });
+  }
 };
 
 module.exports = validateGlobal;

--- a/validateImplementation.js
+++ b/validateImplementation.js
@@ -1,7 +1,5 @@
-const fs = require("fs");
 const path = require("path");
-const xml2js = require("xml2js");
-const error = require("./error");
+const xmlParser = require("./xmlParser");
 const assert = require("./assert");
 
 // XML elements immediately below the root other than
@@ -19,8 +17,7 @@ const permittedTopLevelElements = new Set([
 const validateImplementation = folderInfo => {
   folderInfo.implementationFiles.forEach(implementationFile => {
     let implementationFileName = path.basename(implementationFile);
-    let contents = fs.readFileSync(implementationFile);
-    let parser = new xml2js.Parser();
+    let { contents, xml } = xmlParser(implementationFile);
 
     assert.isTrue(
       !contents.includes("<db:dynamic-query>"),
@@ -32,18 +29,12 @@ const validateImplementation = folderInfo => {
       `${implementationFileName}: Inline SQL should be moved to file/template`
     );
 
-    parser.parseString(contents, (err, result) => {
-      if (err) {
-        error.fatal(err);
-      }
-
-      for (let topLevelElement in result.mule) {
-        assert.isTrue(
-          permittedTopLevelElements.has(topLevelElement),
-          `${implementationFileName}: ${topLevelElement} is not permitted`
-        );
-      }
-    });
+    for (let topLevelElement in xml.mule) {
+      assert.isTrue(
+        permittedTopLevelElements.has(topLevelElement),
+        `${implementationFileName}: ${topLevelElement} is not permitted`
+      );
+    }
   });
 };
 

--- a/validateProperties.js
+++ b/validateProperties.js
@@ -1,6 +1,7 @@
 const {
   propertyPlaceholderRegEx,
-  cloudCIOnlyMavenProperties
+  cloudCIOnlyMavenProperties,
+  encoding
 } = require("./constants");
 const fs = require("fs");
 const path = require("path");
@@ -13,8 +14,7 @@ const sensitiveValueRegEx = /password=(?!replace|\${)/;
 // Loads a Java .properties file into a Map.
 const loadProperties = fileName =>
   fs
-    .readFileSync(fileName)
-    .toString()
+    .readFileSync(fileName, encoding)
     .split(os.EOL)
     .reduce((acc, cur) => {
       // Any space between the key and value is removed.

--- a/xmlParser.js
+++ b/xmlParser.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const xml2js = require("xml2js");
+const error = require("./error");
+const { encoding } = require("./constants");
+
+const xmlParser = file => {
+  let contents = fs.readFileSync(file, encoding);
+  let parser = new xml2js.Parser();
+  let xml;
+
+  // synchronous by default in current version of xml2js
+  parser.parseString(contents, (err, result) => {
+    if (err) {
+      error.fatal(`Unable to parse XML file "${file}": ${err}`);
+    }
+
+    xml = result;
+  });
+
+  return {
+    contents,
+    xml
+  };
+};
+
+module.exports = xmlParser;


### PR DESCRIPTION
Include the filename in XML parsing errors.

Centralize parsing of XML.

Specify the encoding when reading text files. (See https://stackoverflow.com/questions/6456864/why-does-node-js-fs-readfile-return-a-buffer-instead-of-string)

This addresses the latter part of https://github.com/UFGInsurance/mulint/issues/37

Previous output when there was an XML parsing error:
```
[error]  Error: Unexpected close tag
Line: 69
Column: 7
Char: >

1 problem found (1 error, 0 warnings)
```
---
New output:
```
[error]  Unable to parse XML file "C:\SourceCode\mulesoft-apis\System APIs\wsflx-system-api\impl\wsflx-system-api\src\main\app\global.xml": Error: Unexpected close tag
Line: 69
Column: 7
Char: >

1 problem found (1 error, 0 warnings)
```