### PR TITLE
Allow more flexibility in DataWeave folder name

### DIFF
--- a/folderParser.js
+++ b/folderParser.js
@@ -44,7 +44,7 @@ const folderParser = apiBasePath => {
     "api.Development.properties"
   );
   const log4jFile = path.join(resourcesFolder, "log4j2.xml");
-  const dataWeaveFiles = glob.sync(path.join(resourcesFolder, "dwl", "*.dwl"));
+  const dataWeaveFiles = glob.sync(path.join(resourcesFolder, "+(dwl|dw)", "*.dwl"));
 
   if (!fs.existsSync(projectFolder)) {
     error.fatal(`Project folder "${projectFolder}" not found`);

--- a/folderParser.js
+++ b/folderParser.js
@@ -44,7 +44,7 @@ const folderParser = apiBasePath => {
     "api.Development.properties"
   );
   const log4jFile = path.join(resourcesFolder, "log4j2.xml");
-  const dataWeaveFiles = glob.sync(path.join(resourcesFolder, "+(dwl|dw)", "*.dwl"));
+  const dataWeaveFiles = glob.sync(path.join(resourcesFolder, "**", "*.dwl"));
 
   if (!fs.existsSync(projectFolder)) {
     error.fatal(`Project folder "${projectFolder}" not found`);

--- a/mulint.js
+++ b/mulint.js
@@ -15,7 +15,7 @@ const validateDataWeaveFiles = require("./validateDataWeaveFiles");
 const assert = require("./assert");
 
 program
-  .version("1.3.1")
+  .version("1.4.0")
   .description("Mule project linter")
   .arguments("<apiBasePath>")
   .on("--help", () => {


### PR DESCRIPTION
Allow .dwl files (DataWeave) anywhere under `resources` (even in nested folders).

See https://github.com/isaacs/node-glob#glob-primer