### PR TITLE
Permit relative paths on command line (run from anywhere)

### DIFF
--- a/folderParser.js
+++ b/folderParser.js
@@ -20,8 +20,9 @@ const folderParser = apiBasePath => {
     error.fatal(`apiBasePath "${apiBasePath}" not found`);
   }
 
-  const apiName = path.basename(apiBasePath);
-  const projectFolder = path.join(apiBasePath, "impl", apiName);
+  const apiAbsoluteBasePath = path.resolve(apiBasePath);
+  const apiName = path.basename(apiAbsoluteBasePath);
+  const projectFolder = path.join(apiAbsoluteBasePath, "impl", apiName);
   const pomFile = path.join(projectFolder, "pom.xml");
   const gitignoreFile = path.join(projectFolder, ".gitignore");
   const appFolder = path.join(projectFolder, "src", "main", "app");

--- a/folderParser.js
+++ b/folderParser.js
@@ -105,7 +105,6 @@ const folderParser = apiBasePath => {
   }
 
   return {
-    apiBasePath,
     apiName,
     projectFolder,
     pomFile,

--- a/mulint.js
+++ b/mulint.js
@@ -14,7 +14,7 @@ const validateLog4j = require("./validateLog4j");
 const assert = require("./assert");
 
 program
-  .version("1.5.0")
+  .version("1.6.0")
   .description("Mule project linter")
   .arguments("<apiBasePath>")
   .on("--help", () => {


### PR DESCRIPTION
`mulint .` works now.

Should be cross-platform; could someone please try it on a Mac?

Fixes #43 