### PR TITLE
Remove log4j2 database logging checks

### DIFF
--- a/mulint.js
+++ b/mulint.js
@@ -14,7 +14,7 @@ const validateLog4j = require("./validateLog4j");
 const assert = require("./assert");
 
 program
-  .version("1.6.0")
+  .version("1.7.0")
   .description("Mule project linter")
   .arguments("<apiBasePath>")
   .on("--help", () => {

--- a/validateLog4j.js
+++ b/validateLog4j.js
@@ -1,50 +1,5 @@
 const xmlParser = require("./xmlParser");
-const error = require("./error");
 const assert = require("./assert");
-
-// eslint-disable-next-line quotes
-const expectedRoutingScript = '"${mule.env}".equals("local") ? "local" : "DB";';
-
-const validateTemplateIsCurrent = (xml, databaseRoute) => {
-  let routingScript = xml.Configuration.Appenders[0].Routing[0].Script[0][
-    "_"
-  ].trim();
-
-  assert.equals(expectedRoutingScript, routingScript, "Log4j Routing Script");
-
-  let localRoute = xml.Configuration.Appenders[0].Routing[0].Routes[0].Route.find(
-    route => route["$"].key === "local"
-  );
-
-  if (!localRoute) {
-    // very old template
-    error.fatal("Log4j local Route not found - check case of key");
-  }
-
-  assert.equals("file", localRoute["$"].ref, "Log4j local Route");
-
-  assert.equals(
-    "Routing",
-    xml.Configuration.Loggers[0].AsyncRoot[0].AppenderRef[0]["$"].ref,
-    "Log4j AppenderRef"
-  );
-
-  let muleSoftEnvColumn = databaseRoute.JDBC[0].Column.find(
-    column => column["$"].name === "MULESOFT_ENV"
-  );
-
-  assert.equals(
-    "'${mule.env}'",
-    muleSoftEnvColumn["$"].literal,
-    "Log4 JDBC MULESOFT_ENV literal"
-  );
-
-  assert.equals(
-    "MULESOFT_LOGS",
-    databaseRoute.JDBC[0]["$"].tableName,
-    "Log4 JDBC tableName"
-  );
-};
 
 const validateLog4j = folderInfo => {
   let { xml } = xmlParser(folderInfo.log4jFile);
@@ -63,22 +18,6 @@ const validateLog4j = folderInfo => {
     rollingFileAttributes.filePattern,
     "Log4j RollingFile filePattern"
   );
-
-  let databaseRoute = xml.Configuration.Appenders[0].Routing[0].Routes[0].Route.find(
-    route => route["$"].key === "DB"
-  );
-
-  let apiNameColumn = databaseRoute.JDBC[0].Column.find(
-    column => column["$"].name === "API_NAME"
-  );
-
-  assert.equals(
-    `'${folderInfo.apiName}'`,
-    apiNameColumn["$"].literal,
-    "Log4 JDBC API_NAME literal"
-  );
-
-  validateTemplateIsCurrent(xml, databaseRoute);
 };
 
 module.exports = validateLog4j;

--- a/validateLog4j.js
+++ b/validateLog4j.js
@@ -1,11 +1,23 @@
 const xmlParser = require("./xmlParser");
+const error = require("./error");
 const assert = require("./assert");
 
 const validateLog4j = folderInfo => {
   let { xml } = xmlParser(folderInfo.log4jFile);
 
-  let rollingFileAttributes =
-    xml.Configuration.Appenders[0].RollingFile[0]["$"];
+  let appenders = xml.Configuration.Appenders;
+
+  if (!appenders) {
+    error.fatal("Log4j Appenders not found");
+  }
+
+  let rollingFileAppender = appenders[0].RollingFile;
+
+  if (!rollingFileAppender) {
+    error.fatal("Log4j RollingFile appender not found");
+  }
+
+  let rollingFileAttributes = rollingFileAppender[0]["$"];
 
   assert.matches(
     new RegExp(`${folderInfo.apiName}\\.log$`),


### PR DESCRIPTION
Since we're looking at removing database logging, this no longer makes sense.

Also improve log4j2 error handling for missing elements.

Fixes #45 