### PR TITLE
Improve sensitive info check

### DIFF
--- a/mulint.js
+++ b/mulint.js
@@ -14,7 +14,7 @@ const validateLog4j = require("./validateLog4j");
 const assert = require("./assert");
 
 program
-  .version("1.7.0")
+  .version("1.8.0")
   .description("Mule project linter")
   .arguments("<apiBasePath>")
   .on("--help", () => {

--- a/validateProperties.js
+++ b/validateProperties.js
@@ -10,8 +10,10 @@ const assert = require("./assert");
 
 const sensitiveKeyRegEx = /password|pwd/i;
 
+// Primarily for Microsoft SQL Server connection strings
 // Negative lookahead - "password=" not followed by "replace" or "${"
-const sensitiveValueRegEx = /password=(?!replace|\${)/;
+// (Case-insensitive, ignoring whitespace)
+const sensitiveValueRegEx = /password\s*=(?!\s*(?:replace|\${))/i;
 
 // Loads a Java .properties file into a Map.
 const loadProperties = fileName =>

--- a/validateProperties.js
+++ b/validateProperties.js
@@ -15,6 +15,8 @@ const sensitiveKeyRegEx = /password|pwd/i;
 // (Case-insensitive, ignoring whitespace)
 const sensitiveValueRegEx = /password\s*=(?!\s*(?:replace|\${))/i;
 
+const securedPropertyRegEx = /^!\[.+\]$/;
+
 // Loads a Java .properties file into a Map.
 const loadProperties = fileName =>
   fs
@@ -103,6 +105,7 @@ const validateProperties = (folderInfo, pomInfo) => {
     if (
       (sensitiveKeyRegEx.test(key) &&
         !value.toUpperCase().includes("REPLACE") &&
+        !securedPropertyRegEx.test(value) &&
         !propertyPlaceholderRegEx.test(value)) ||
       sensitiveValueRegEx.test(value)
     ) {

--- a/validateProperties.js
+++ b/validateProperties.js
@@ -102,7 +102,7 @@ const validateProperties = (folderInfo, pomInfo) => {
 
     if (
       (sensitiveKeyRegEx.test(key) &&
-        !value.includes("replace") &&
+        !value.toUpperCase().includes("REPLACE") &&
         !propertyPlaceholderRegEx.test(value)) ||
       sensitiveValueRegEx.test(value)
     ) {

--- a/validateProperties.js
+++ b/validateProperties.js
@@ -8,6 +8,8 @@ const path = require("path");
 const os = require("os");
 const assert = require("./assert");
 
+const sensitiveKeyRegEx = /password|pwd/i;
+
 // Negative lookahead - "password=" not followed by "replace" or "${"
 const sensitiveValueRegEx = /password=(?!replace|\${)/;
 
@@ -97,7 +99,7 @@ const validateProperties = (folderInfo, pomInfo) => {
     );
 
     if (
-      (key.includes("password") &&
+      (sensitiveKeyRegEx.test(key) &&
         !value.includes("replace") &&
         !propertyPlaceholderRegEx.test(value)) ||
       sensitiveValueRegEx.test(value)


### PR DESCRIPTION
Better checking of local .properties files.

**Examples:**

`gwbc.pwd=secret`
results in
`[warning]  api.local.properties: gwbc.pwd may contain sensitive information`

`gwbc.pwd=REPLACE`
does not result in a sensitivity warning.

`db.connection=Server = s; Database = db; User Id = u; Password = myPassword;`
results in
`[warning]  api.local.properties: db.connection may contain sensitive information`

`db.connection=Server = s; Database = db; User Id = u; Password = ${myPassword};`
does not result in a sensitivity warning.

`sftp.password=![AAAAAAAAAAAAAAAAAAAAAA==]`
does not result in a sensitivity warning.

Fixes #47 