### PR TITLE
Check POM for sensitive property values

### DIFF
--- a/mulint.js
+++ b/mulint.js
@@ -14,7 +14,7 @@ const validateLog4j = require("./validateLog4j");
 const assert = require("./assert");
 
 program
-  .version("1.8.0")
+  .version("1.9.0")
   .description("Mule project linter")
   .arguments("<apiBasePath>")
   .on("--help", () => {

--- a/sensitive.js
+++ b/sensitive.js
@@ -11,6 +11,7 @@ const securedPropertyRegEx = /^!\[.+\]$/;
 
 const isSensitive = (key, value) =>
   (sensitiveKeyRegEx.test(key) &&
+    value &&
     !value.toUpperCase().includes("REPLACE") &&
     !securedPropertyRegEx.test(value) &&
     !propertyPlaceholderRegEx.test(value)) ||

--- a/sensitive.js
+++ b/sensitive.js
@@ -1,0 +1,21 @@
+const { propertyPlaceholderRegEx } = require("./constants");
+
+const sensitiveKeyRegEx = /password|pwd/i;
+
+// Primarily for Microsoft SQL Server connection strings
+// Negative lookahead - "password=" not followed by "replace" or "${"
+// (Case-insensitive, ignoring whitespace)
+const sensitiveValueRegEx = /password\s*=(?!\s*(?:replace|\${))/i;
+
+const securedPropertyRegEx = /^!\[.+\]$/;
+
+const isSensitive = (key, value) =>
+  (sensitiveKeyRegEx.test(key) &&
+    !value.toUpperCase().includes("REPLACE") &&
+    !securedPropertyRegEx.test(value) &&
+    !propertyPlaceholderRegEx.test(value)) ||
+  sensitiveValueRegEx.test(value);
+
+module.exports = {
+  isSensitive
+};

--- a/validatePom.js
+++ b/validatePom.js
@@ -3,6 +3,7 @@ const {
   cloudCIOnlyMavenProperties
 } = require("./constants");
 const assert = require("./assert");
+const sensitive = require("./sensitive");
 
 const domainProjectName = "api-gateway";
 const expectedDomainProjectVersionRegEx = /^1\.0\.[3-9]$/;
@@ -108,6 +109,12 @@ const validatePom = (folderInfo, pomInfo) => {
       distributionManagement[0].repository[0].url[0] === mavenRepository,
     "POM: Maven repository (Artifactory) not configured"
   );
+
+  pomInfo.properties.forEach((value, key) => {
+    if (sensitive.isSensitive(key, value)) {
+      assert.fail(`POM: ${key} may contain sensitive information`);
+    }
+  });
 };
 
 module.exports = validatePom;


### PR DESCRIPTION
Failure example:

POM property:
`<cache.database.url>...;password=secret</cache.database.url>`

Result:
`[warning]  POM: cache.database.url may contain sensitive information`

Empty `deployment.pwd` element is permitted.