### PR TITLE
Now assumes on-prem if no Mule Maven Plugin.

### DIFF
--- a/mulint.js
+++ b/mulint.js
@@ -14,7 +14,7 @@ const validateLog4j = require("./validateLog4j");
 const assert = require("./assert");
 
 program
-  .version("1.9.0")
+  .version("2.0.0")
   .description("Mule project linter")
   .arguments("<apiBasePath>")
   .on("--help", () => {

--- a/pomParser.js
+++ b/pomParser.js
@@ -9,10 +9,29 @@ const pomParser = pomFile => {
     properties.set(property, xmlProperties[property][0]);
   }
 
-  let isOnPrem = properties.get("deployment.type") === "arm";
+  let dependencies = xml.project.dependencies[0].dependency;
+  let plugins = xml.project.build[0].plugins[0].plugin;
+
+  // Curryable function
+  const findElementByArtifactId = elements => artifactId =>
+    elements.find(
+      element => element.artifactId && element.artifactId[0] === artifactId
+    );
+
+  const findDependency = findElementByArtifactId(dependencies);
+  const findPlugin = findElementByArtifactId(plugins);
+
+  let muleMavenPlugin = findPlugin("mule-maven-plugin");
+
+  // Currently assuming if not using the Mule Maven Plugin then deploying on-prem.
+  let isOnPrem =
+    !muleMavenPlugin || properties.get("deployment.type") === "arm";
 
   return {
+    findDependency,
+    findPlugin,
     properties,
+    muleMavenPlugin,
     isOnPrem,
     xml
   };

--- a/validatePom.js
+++ b/validatePom.js
@@ -13,19 +13,7 @@ const mavenRepository =
   "https://ufginsurance.jfrog.io/ufginsurance/libs-release-local";
 
 const validatePom = (folderInfo, pomInfo) => {
-  let dependencies = pomInfo.xml.project.dependencies[0].dependency;
-  let plugins = pomInfo.xml.project.build[0].plugins[0].plugin;
-
-  // Curryable function
-  const findElementByArtifactId = elements => artifactId =>
-    elements.find(
-      element => element.artifactId && element.artifactId[0] === artifactId
-    );
-
-  let findDependency = findElementByArtifactId(dependencies);
-  let findPlugin = findElementByArtifactId(plugins);
-
-  let domainProject = findDependency(domainProjectName);
+  let domainProject = pomInfo.findDependency(domainProjectName);
 
   if (pomInfo.isOnPrem) {
     assert.isTrue(domainProject, "No domain project (deploying on-prem)");
@@ -45,10 +33,8 @@ const validatePom = (folderInfo, pomInfo) => {
       "Domain project used (deploying to CloudHub)"
     );
 
-    let muleMavenPlugin = findPlugin("mule-maven-plugin");
-
-    if (muleMavenPlugin && muleMavenPlugin.configuration) {
-      let mavenProperties = muleMavenPlugin.configuration[0].properties;
+    if (pomInfo.muleMavenPlugin && pomInfo.muleMavenPlugin.configuration) {
+      let mavenProperties = pomInfo.muleMavenPlugin.configuration[0].properties;
 
       if (mavenProperties) {
         cloudCIOnlyMavenProperties.forEach(ciOnlyProperty => {
@@ -75,7 +61,7 @@ const validatePom = (folderInfo, pomInfo) => {
   }
 
   assert.isTrue(
-    findDependency("common-dataweave"),
+    pomInfo.findDependency("common-dataweave"),
     "No 'common-dataweave' project dependency"
   );
 


### PR DESCRIPTION
Version 2.0.0 (technically breaking change).

Eventually we could add a CloudHub command-line flag or some such if desired.

Fixes #56 