### PR TITLE
Update minimum Node version (issue w/v8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Pronounced *MEW-lint*. :smile_cat:
 
 #### Prerequisites
 
-- [Node.js](https://nodejs.org/) 8.10 or later (**LTS**)
+- [Node.js](https://nodejs.org/) 10.15.3 or later (**LTS**)
     - _(nodejs-lts package for Chocolatey users)_
 - [Yarn](https://yarnpkg.com/)
 


### PR DESCRIPTION
Running before and after upgrading from Node v8.11.4 to Node v10.15.3 gave different results in mulint (with the later version being accurate).