### PR TITLE
Add command-line switch for detect deployment type

### DIFF
--- a/mulint.js
+++ b/mulint.js
@@ -17,6 +17,7 @@ program
   .version("2.0.1")
   .description("Mule project linter")
   .arguments("<apiBasePath>")
+  .option("-d, --detect-deploy", "Detect deployment type (otherwise assumes on-prem)")
   .on("--help", () => {
     const path = "C:\\SourceCode\\mulesoft-apis\\System APIs\\wsflx-system-api";
     console.log("");
@@ -30,7 +31,8 @@ program
     apiBasePath = apiBasePath.replace(/"$/, "");
 
     let folderInfo = folderParser(apiBasePath);
-    let pomInfo = pomParser(folderInfo.pomFile);
+    let pomInfo = pomParser(folderInfo.pomFile, program.detectDeploy);
+    
     validateApiFiles(folderInfo, pomInfo);
     validatePom(folderInfo, pomInfo);
     validateGlobal(folderInfo);

--- a/mulint.js
+++ b/mulint.js
@@ -14,7 +14,7 @@ const validateLog4j = require("./validateLog4j");
 const assert = require("./assert");
 
 program
-  .version("2.1.0")
+  .version("3.0.0")
   .description("Mule project linter")
   .arguments("<apiBasePath>")
   .option("-d, --detect-deploy", "Detect deployment type (otherwise assumes on-prem)")

--- a/mulint.js
+++ b/mulint.js
@@ -14,7 +14,7 @@ const validateLog4j = require("./validateLog4j");
 const assert = require("./assert");
 
 program
-  .version("2.0.1")
+  .version("2.1.0")
   .description("Mule project linter")
   .arguments("<apiBasePath>")
   .option("-d, --detect-deploy", "Detect deployment type (otherwise assumes on-prem)")

--- a/pomParser.js
+++ b/pomParser.js
@@ -1,6 +1,6 @@
 const xmlParser = require("./xmlParser");
 
-const pomParser = pomFile => {
+const pomParser = (pomFile, detectDeploy) => {
   let { xml } = xmlParser(pomFile);
   let xmlProperties = xml.project.properties[0];
   let properties = new Map();
@@ -23,9 +23,15 @@ const pomParser = pomFile => {
 
   let muleMavenPlugin = findPlugin("mule-maven-plugin");
 
-  // Currently assuming if not using the Mule Maven Plugin then deploying on-prem.
-  let isOnPrem =
-    !muleMavenPlugin || properties.get("deployment.type") === "arm";
+  let isOnPrem;
+  
+  if (detectDeploy) {
+    // Currently assuming if not using the Mule Maven Plugin then deploying on-prem.
+    isOnPrem =
+      !muleMavenPlugin || properties.get("deployment.type") === "arm";
+  } else {
+    isOnPrem = true;
+  }
 
   return {
     findDependency,


### PR DESCRIPTION
Specifying `-d` or `--detect-deploy` on the command line will cause mulint to detect the deployment type (on-prem or CloudHub). This is the current behavior. Omitting that means that mulint will assume on-prem deployment.