### PR TITLE
Skip http:listener path check if using property placeholder

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -20,10 +20,16 @@ const isTrue = (expression, message) => {
 
 const fail = message => failures.push(message);
 
+// For tests - do not want to change reference
+const clearFailures = () => {
+  failures.length = 0;
+};
+
 module.exports = {
   failures,
   equals,
   matches,
   isTrue,
-  fail
+  fail,
+  clearFailures
 };

--- a/constants.js
+++ b/constants.js
@@ -1,4 +1,5 @@
 const propertyPlaceholderRegEx = /^\${.+}$/;
+const propertyPlaceholderAnywhereRegEx = /\${.+}/;
 
 // Maven properties added by TeamCity that should not be stored in project
 const cloudCIOnlyMavenProperties = [
@@ -10,6 +11,7 @@ const encoding = "utf8";
 
 module.exports = {
   propertyPlaceholderRegEx,
+  propertyPlaceholderAnywhereRegEx,
   cloudCIOnlyMavenProperties,
   encoding
 };

--- a/mulint.js
+++ b/mulint.js
@@ -8,7 +8,7 @@ const program = require("commander");
 const api = require("./api");
 
 program
-  .version("2.0.2")
+  .version("2.1.2")
   .description("Mule project linter")
   .arguments("<apiBasePath>")
   .on("--help", () => {

--- a/validateApiFile.js
+++ b/validateApiFile.js
@@ -1,4 +1,5 @@
 const assert = require("./assert");
+const { propertyPlaceholderAnywhereRegEx } = require("./constants");
 
 const expectedOnPremListenerConfig = "standardHTTPS";
 const expectedListenerPathRegEx = /^\/(?:console|api)\/.+\/v1\/(?:.+\/)?\*$/;
@@ -18,11 +19,14 @@ const validateApiFile = (apiFileName, xml, pomInfo) => {
         );
       }
 
-      assert.matches(
-        expectedListenerPathRegEx,
-        listenerAttributes["path"],
-        `${apiFileName} http:listener path`
-      );
+      // Skip the check if there's a property placeholder (like ${api.basepath}) present.
+      if (!propertyPlaceholderAnywhereRegEx.test(listenerAttributes["path"])) {
+        assert.matches(
+          expectedListenerPathRegEx,
+          listenerAttributes["path"],
+          `${apiFileName} http:listener path`
+        );
+      }
     }
 
     let exceptionStrategy = flow["exception-strategy"];

--- a/validateApiFile.test.js
+++ b/validateApiFile.test.js
@@ -1,0 +1,80 @@
+const validateApiFile = require("./validateApiFile");
+const assert = require("./assert");
+const xml2js = require("xml2js");
+
+const valid = `<?xml version="1.0" encoding="UTF-8"?>
+<mule >
+	<apikit:config name="api-config" raml="api.raml" consoleEnabled="false" doc:name="Router" />
+	<flow name="api-main">
+		<http:listener config-ref="standardHTTPS" path="/api/foo/v1/*" doc:name="HTTP" />
+		<apikit:router config-ref="api-config" doc:name="APIkit Router" />
+		<exception-strategy ref="ChoiceExceptionStrategy" doc:name="Reference Exception Strategy" />
+	</flow>
+	<flow name="api-console">
+		<http:listener config-ref="standardHTTPS" path="\${api.basepath}" doc:name="HTTP" />
+		<apikit:console config-ref="api-config" doc:name="APIkit Console" />
+        <exception-strategy ref="ChoiceExceptionStrategy" doc:name="Reference Exception Strategy"/>
+	</flow>
+	<flow name="get:/foo:api-config">
+		<flow-ref name="getSubflow" doc:name="Call getSubflow" />
+        <exception-strategy ref="ChoiceExceptionStrategy" doc:name="Reference Exception Strategy"/>
+	</flow>
+</mule>`;
+
+const invalidListener = `<?xml version="1.0" encoding="UTF-8"?>
+<mule >
+	<apikit:config name="api-config" raml="api.raml" consoleEnabled="false" doc:name="Router" />
+	<flow name="api-main">
+		<http:listener config-ref="standardHTTPS" path="/bad/foo/v1/*" doc:name="HTTP" />
+		<apikit:router config-ref="api-config" doc:name="APIkit Router" />
+		<exception-strategy ref="ChoiceExceptionStrategy" doc:name="Reference Exception Strategy" />
+	</flow>
+	<flow name="api-console">
+		<http:listener config-ref="standardHTTPS" path="\${api.basepath}" doc:name="HTTP" />
+		<apikit:console config-ref="api-config" doc:name="APIkit Console" />
+        <exception-strategy ref="ChoiceExceptionStrategy" doc:name="Reference Exception Strategy"/>
+	</flow>
+	<flow name="get:/foo:api-config">
+		<flow-ref name="getSubflow" doc:name="Call getSubflow" />
+        <exception-strategy ref="ChoiceExceptionStrategy" doc:name="Reference Exception Strategy"/>
+	</flow>
+</mule>`;
+
+describe("validateApiFile", () => {
+  beforeEach(() => {
+    assert.clearFailures();
+  });
+
+  afterEach(() => {
+    assert.clearFailures();
+  });
+
+  it("should pass on a valid file", () => {
+    let parser = new xml2js.Parser();
+    let xml;
+    let pomInfo = { isOnPrem: true };
+
+    parser.parseString(valid, (_, result) => {
+      xml = result;
+    });
+
+    validateApiFile("api.xml", xml, pomInfo);
+
+    expect(assert.failures).toEqual([]);
+  });
+
+  it("should fail on invalid http:listener path", () => {
+    let parser = new xml2js.Parser();
+    let xml;
+    let pomInfo = { isOnPrem: true };
+
+    parser.parseString(invalidListener, (_, result) => {
+      xml = result;
+    });
+
+    validateApiFile("api.xml", xml, pomInfo);
+
+    expect(assert.failures.length).toBe(1);
+    expect(assert.failures[0]).toMatch("http:listener path");
+  });
+});


### PR DESCRIPTION
For example, allow
`<http:listener config-ref="standardHTTPS" path="/console${api.basepath}" doc:name="HTTP" />`

We're using Octopus Deploy variables for the api.basepath, to support multiple MuleSoft dev and qa instances (labels) that are compiled using the same source code.